### PR TITLE
Update XLWorkbook_Load.cs

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1426,6 +1426,7 @@ namespace ClosedXML.Excel
 
                         case CellValues.InlineString:
                         case CellValues.SharedString:
+                        case CellValues.String:
                             xlCell.SetDataTypeFast(XLDataType.Text);
                             break;
                     }
@@ -1484,6 +1485,7 @@ namespace ClosedXML.Excel
 
                         case CellValues.InlineString:
                         case CellValues.SharedString:
+                        case CellValues.String:
                             xlCell.SetDataTypeFast(XLDataType.Text);
                             break;
                     }
@@ -1525,6 +1527,17 @@ namespace ClosedXML.Excel
                     }
                     else
                         xlCell.SetInternalCellValueString(String.Empty);
+                }
+                else if (cell.DataType == CellValues.String) 
+                {
+                    xlCell.SetDataTypeFast(XLDataType.Text);
+                    
+                    if (cell.CellValue != null && !String.IsNullOrEmpty(cell.CellValue.Text)) 
+                        xlCell.SetInternalCellValueString(cell.CellValue.Text);
+                    else
+                        xlCell.SetInternalCellValueString(String.Empty);
+                        
+                    
                 }
                 else if (cell.DataType == CellValues.Date)
                 {


### PR DESCRIPTION
Fix bug with unsupported CellValues.String DataType at the file loading step.
If excel file had cells with CellValues.String DataType values of these cells were missed.
